### PR TITLE
Fix GitHub references to master branch

### DIFF
--- a/.github/workflows/generate-notebooks.yml
+++ b/.github/workflows/generate-notebooks.yml
@@ -3,7 +3,7 @@ name: Validate starter notebooks
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 
 jobs:
   execute-notebooks:

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import requests
 
-RAW_BASE = "https://raw.githubusercontent.com/DavidLangworthy/ds4s/main/"
+RAW_BASE = "https://raw.githubusercontent.com/DavidLangworthy/ds4s/master/"
 
 
 def ensure_local_path(relative_path: str, *, base_url: str = RAW_BASE) -> Path:


### PR DESCRIPTION
## Summary
- point the workflow push trigger at the master branch
- fetch raw assets from the master branch in the shared utils module

## Testing
- python -m compileall utils.py

------
https://chatgpt.com/codex/tasks/task_e_68cf126ea0288323b9ff7b20674d845a